### PR TITLE
re-target to net6.0,net8.0,netstandard2.0

### DIFF
--- a/NodifyM.Avalonia.Example/MainWindow.axaml
+++ b/NodifyM.Avalonia.Example/MainWindow.axaml
@@ -79,6 +79,11 @@
                                 <SolidColorBrush Color="Red"
                                                  Opacity="0.5" />
                             </controls:Connection.Stroke>
+                            <controls:Connection.ContextMenu>
+                                <ContextMenu>
+                                    <MenuItem Header="_Delete" />
+                                </ContextMenu>
+                            </controls:Connection.ContextMenu>
                         </controls:Connection>
                     </Grid>
 

--- a/NodifyM.Avalonia/NodifyM.Avalonia.csproj
+++ b/NodifyM.Avalonia/NodifyM.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net8;net5;netcoreapp3.1;net472</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Avalonia.Desktop" Version="11.0.10" />
+      <PackageReference Include="Avalonia" Version="11.0.10" />
       <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.10" />
       <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
         <PackageReference Include="System.Reactive" Version="6.0.1"/>


### PR DESCRIPTION
This PR removes the dependency on `Avalonia.Desktop` and re-target the library to the `net6.0,net8.0,netstandard2.0` frameworks.